### PR TITLE
Добавление репозиториев для хранения деревьев и стратегии сериализации

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.8.10"
+    kotlin("jvm") version "1.8.10"
+    kotlin("plugin.serialization") version "1.8.10"
     id("io.ktor.plugin") version "2.2.4"
     application
 }
@@ -12,6 +13,8 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation(platform("org.junit:junit-bom:5.9.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
+
 }
 
 tasks.test {

--- a/app/src/main/kotlin/app/model/repo/JsonRepo.kt
+++ b/app/src/main/kotlin/app/model/repo/JsonRepo.kt
@@ -1,0 +1,20 @@
+package app.model.repo
+
+import app.model.bst.BinarySearchTree
+import app.model.bst.node.BinTreeNode
+import app.model.repo.serialization.strategy.SerializationStrategy
+
+class JsonRepo<E : Comparable<E>,
+        Node : BinTreeNode<E, Node>,
+        BST : BinarySearchTree<E, Node>>(
+    strategy: SerializationStrategy<E, Node>
+) : Repository<E, Node, BST>(strategy) {
+    override fun save(tree: BST) {
+        TODO("Not yet implemented")
+    }
+
+    override fun load(factory: () -> BST): BST {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/app/src/main/kotlin/app/model/repo/Neo4jRepo.kt
+++ b/app/src/main/kotlin/app/model/repo/Neo4jRepo.kt
@@ -1,0 +1,20 @@
+package app.model.repo
+
+import app.model.bst.BinarySearchTree
+import app.model.bst.node.BinTreeNode
+import app.model.repo.serialization.strategy.SerializationStrategy
+
+class Neo4jRepo<E : Comparable<E>,
+        Node : BinTreeNode<E, Node>,
+        BST : BinarySearchTree<E, Node>>(
+    strategy: SerializationStrategy<E, Node>
+) : Repository<E, Node, BST>(strategy) {
+    override fun save(tree: BST) {
+        TODO("Not yet implemented")
+    }
+
+    override fun load(factory: () -> BST): BST {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/app/src/main/kotlin/app/model/repo/PostgresRepo.kt
+++ b/app/src/main/kotlin/app/model/repo/PostgresRepo.kt
@@ -1,0 +1,20 @@
+package app.model.repo
+
+import app.model.bst.BinarySearchTree
+import app.model.bst.node.BinTreeNode
+import app.model.repo.serialization.strategy.SerializationStrategy
+
+class PostgresRepo<E : Comparable<E>,
+        Node : BinTreeNode<E, Node>,
+        BST : BinarySearchTree<E, Node>>(
+    strategy: SerializationStrategy<E, Node>
+) : Repository<E, Node, BST>(strategy) {
+    override fun save(tree: BST) {
+        TODO("Not yet implemented")
+    }
+
+    override fun load(factory: () -> BST): BST {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/app/src/main/kotlin/app/model/repo/Repository.kt
+++ b/app/src/main/kotlin/app/model/repo/Repository.kt
@@ -1,0 +1,24 @@
+package app.model.repo
+
+import app.model.bst.BinarySearchTree
+import app.model.bst.node.BinTreeNode
+import app.model.repo.serialization.SerializableNode
+import app.model.repo.serialization.strategy.SerializationStrategy
+
+abstract class Repository<E : Comparable<E>,
+        Node : BinTreeNode<E, Node>,
+        BST : BinarySearchTree<E, Node>>(
+    protected val strategy: SerializationStrategy<E, Node>
+) {
+    protected fun Node.toSerializableNode(): SerializableNode {
+        return SerializableNode(
+            strategy.collectValue(this),
+            strategy.collectMetadata(this),
+            left?.toSerializableNode(),
+            right?.toSerializableNode()
+        )
+    }
+
+    abstract fun save(tree: BST)
+    abstract fun load(factory: () -> BST): BST
+}

--- a/app/src/main/kotlin/app/model/repo/serialization/Serializable.kt
+++ b/app/src/main/kotlin/app/model/repo/serialization/Serializable.kt
@@ -1,0 +1,32 @@
+package app.model.repo.serialization
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class TypeOfTree(val savingName: String) {
+    BINARY_SEARCH_TREE("BINARY_SEARCH_TREE"),
+    RED_BLACK_TREE("RED_BLACK_TREE"),
+    AVL_TREE("AVL_TREE")
+}
+
+@Serializable
+class SerializableNode(
+    val value: SerializableValue,
+    val metadata: Metadata,
+    val left: SerializableNode? = null,
+    val right: SerializableNode? = null,
+)
+
+@Serializable
+class SerializableTree(
+    val typeOfTree: TypeOfTree,
+    val root: SerializableNode?
+)
+
+@Serializable
+@JvmInline
+value class Metadata(val value: String)
+
+@Serializable
+@JvmInline
+value class SerializableValue(val value: String)

--- a/app/src/main/kotlin/app/model/repo/serialization/strategy/SerializationStrategy.kt
+++ b/app/src/main/kotlin/app/model/repo/serialization/strategy/SerializationStrategy.kt
@@ -1,0 +1,15 @@
+package app.model.repo.serialization.strategy
+
+import app.model.bst.node.BinTreeNode
+import app.model.repo.serialization.Metadata
+import app.model.repo.serialization.SerializableNode
+import app.model.repo.serialization.SerializableValue
+import app.model.repo.serialization.TypeOfTree
+
+interface SerializationStrategy<E : Comparable<E>,
+        Node : BinTreeNode<E, Node>> {
+    val typeOfTree: TypeOfTree
+    fun collectMetadata(node: Node): Metadata
+    fun collectValue(node: Node): SerializableValue
+    fun buildNode(node: SerializableNode): Node
+}


### PR DESCRIPTION
Репозитории просто представляют собой конкретную сохранялку сериализуемых данных.
Стратегии - способы представить абстрактный тип конкретным, сериализуемым. Полезны при создании репозиториев.