### PR TITLE
Добавление jacoco для проверки покрытия

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Print coverage report
         env:
           report_path: app/build/coverage/test/jacocoTestReport.csv
-          run: |
+        run: |
             awk -F"," '{ instructions += $4 + $5; covered += $5; branches += $6 + $7; branches_covered +=$7 } END { print "Instructions covered:", covered"/"instructions, "--", 100*covered/instructions"%"; print "Branches covered:", branches_covered"/"branches, "--", 100*branches_covered/branches"%" }' $report_path
 
       - name: Create fat .jar file on main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: Run build with Gradle Wrapper
         run: ./gradlew build
+
+      - name: Print coverage report
+        env:
+          report_path: app/build/coverage/test/jacocoTestReport.csv
+          run: |
+            awk -F"," '{ instructions += $4 + $5; covered += $5; branches += $6 + $7; branches_covered +=$7 } END { print "Instructions covered:", covered"/"instructions, "--", 100*covered/instructions"%"; print "Branches covered:", branches_covered"/"branches, "--", 100*branches_covered/branches"%" }' $report_path
+
       - name: Create fat .jar file on main
         if: ${{ github.ref == 'refs/heads/main' }}
         run: ./gradlew app:buildFatJar
@@ -21,3 +28,9 @@ jobs:
         with:
           name: All in one jar
           path: app/build/libs/app-all.jar
+
+      - uses: actions/upload-artifact@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          name: Upload coverage report
+          path: app/build/coverage/test/*

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,20 @@ plugins {
     kotlin("jvm") version "1.8.20"
     kotlin("plugin.serialization") version "1.8.20"
     id("io.ktor.plugin") version "2.2.4"
+    id("jacoco")
     application
+}
+jacoco {
+    toolVersion = "0.8.7"
+    reportsDirectory.set(layout.buildDirectory.dir("coverage"))
+
+}
+tasks.withType<JacocoReport> {
+    reports {
+        xml.required.set(true)
+        csv.required.set(true)
+        html.required.set(false)
+    }
 }
 
 repositories {
@@ -19,7 +32,9 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
 }
+
 tasks.jar {
     manifest.attributes["Main-Class"] = "app.AppKt"
 }


### PR DESCRIPTION
Добавил jacoco. Репорты сохраняются в виде csv, xml файлов и сохраняются в артефакты