### PR TITLE
Добавление сохранения через neo4j для произвольного дерева

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     kotlin("plugin.serialization") version "1.8.20"
     id("io.ktor.plugin") version "2.2.4"
     id("jacoco")
+    id("org.jetbrains.kotlin.plugin.noarg") version "1.8.20"
+
     application
 }
 jacoco {
@@ -26,6 +28,8 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation(platform("org.junit:junit-bom:5.9.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
+    implementation("org.neo4j:neo4j-ogm-core:4.0.5")
+    runtimeOnly("org.neo4j:neo4j-ogm-bolt-driver:4.0.5")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
 
 }
@@ -38,6 +42,11 @@ tasks.test {
 tasks.jar {
     manifest.attributes["Main-Class"] = "app.AppKt"
 }
+noArg {
+    annotation("org.neo4j.ogm.annotation.NodeEntity")
+    annotation("org.neo4j.ogm.annotation.RelationshipEntity")
+}
+
 kotlin {
     jvmToolchain(8)
 }

--- a/app/src/main/kotlin/app/model/repo/JsonRepo.kt
+++ b/app/src/main/kotlin/app/model/repo/JsonRepo.kt
@@ -9,11 +9,15 @@ class JsonRepo<E : Comparable<E>,
         BST : BinarySearchTree<E, Node>>(
     strategy: SerializationStrategy<E, Node, *>
 ) : Repository<E, Node, BST>(strategy) {
-    override fun save(tree: BST) {
+    override fun save(verboseName: String, tree: BST) {
         TODO("Not yet implemented")
     }
 
-    override fun load(factory: () -> BST): BST {
+    override fun loadByVerboseName(verboseName: String, factory: () -> BST): BST {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteByVerboseName(verboseName: String) {
         TODO("Not yet implemented")
     }
 

--- a/app/src/main/kotlin/app/model/repo/Neo4jRepo.kt
+++ b/app/src/main/kotlin/app/model/repo/Neo4jRepo.kt
@@ -2,19 +2,127 @@ package app.model.repo
 
 import app.model.bst.BinarySearchTree
 import app.model.bst.node.BinTreeNode
+import app.model.repo.serialization.*
 import app.model.repo.serialization.strategy.SerializationStrategy
+import org.neo4j.ogm.annotation.*
+import org.neo4j.ogm.config.Configuration
+import org.neo4j.ogm.cypher.ComparisonOperator
+import org.neo4j.ogm.cypher.Filter
+import org.neo4j.ogm.cypher.Filters
+import org.neo4j.ogm.session.SessionFactory
+
+@NodeEntity
+class SerializableNodeEntity(
+    @Property
+    var value: SerializableValue,
+
+    @Property
+    var metadata: Metadata,
+
+    @Relationship(type = "LEFT")
+    var left: SerializableNodeEntity? = null,
+
+    @Relationship(type = "RIGHT")
+    var right: SerializableNodeEntity? = null,
+) {
+    @Id
+    @GeneratedValue
+    var id: Long? = null
+}
+
+@NodeEntity
+class SerializableTreeEntity(
+    @Property
+    var verboseName: String,
+
+    @Property
+    var typeOfTree: TypeOfTree,
+
+    @Relationship(type = "ROOT")
+    var root: SerializableNodeEntity? = null,
+) {
+
+    @Id
+    @GeneratedValue
+    var id: Long? = null
+
+}
 
 class Neo4jRepo<E : Comparable<E>,
         Node : BinTreeNode<E, Node>,
         BST : BinarySearchTree<E, Node>>(
     strategy: SerializationStrategy<E, Node, *>
 ) : Repository<E, Node, BST>(strategy) {
-    override fun save(tree: BST) {
-        TODO("Not yet implemented")
+    private val configuration = Configuration.Builder()
+        .uri("bolt://localhost")
+        .credentials("neo4j", "password") //TODO: use settings for this parameters
+        .build()
+    private val sessionFactory = SessionFactory(configuration, "app.model.repo")
+    private val session = sessionFactory.openSession()
+
+    private fun SerializableNodeEntity.toNode(): SerializableNode {
+        return SerializableNode(
+            value,
+            metadata,
+            left?.toNode(),
+            right?.toNode()
+        )
     }
 
-    override fun load(factory: () -> BST): BST {
-        TODO("Not yet implemented")
+    private fun SerializableTreeEntity.toTree(): SerializableTree {
+        return SerializableTree(
+            verboseName,
+            typeOfTree,
+            root?.toNode()
+        )
     }
 
+
+    private fun SerializableNode.toEntity(): SerializableNodeEntity {
+        return SerializableNodeEntity(
+            value,
+            metadata,
+            left?.toEntity(),
+            right?.toEntity()
+        )
+    }
+
+    private fun SerializableTree.toEntity(): SerializableTreeEntity {
+        return SerializableTreeEntity(
+            verboseName,
+            typeOfTree,
+            root?.toEntity()
+        )
+    }
+
+    override fun save(verboseName: String, tree: BST) {
+        deleteByVerboseName(verboseName)
+        val entityTree = tree.toSerializableTree(verboseName).toEntity()
+        session.save(entityTree)
+    }
+
+    private fun findByVerboseName(verboseName: String) = session.loadAll(
+        SerializableTreeEntity::class.java,
+        Filters().and(
+            Filter("verboseName", ComparisonOperator.EQUALS, verboseName)
+        ).and(
+            Filter("typeOfTree", ComparisonOperator.EQUALS, strategy.typeOfTree)
+        ),
+        -1
+    )
+
+    override fun loadByVerboseName(verboseName: String, factory: () -> BST): BST {
+        val treeEntity = findByVerboseName(verboseName).singleOrNull()
+
+        return factory().apply {
+            root = strategy.buildNode(treeEntity?.toTree()?.root)
+        }
+    }
+
+    override fun deleteByVerboseName(verboseName: String) {
+        session.query(
+            "MATCH toDelete=(t:SerializableTreeEntity {typeOfTree: '\$typeOfTree', verboseName : '\$verboseName'})-[*]->() DETACH DELETE toDelete",
+            mapOf("typeOfTree" to strategy.typeOfTree, "verboseName" to verboseName)
+        )
+    }
 }

--- a/app/src/main/kotlin/app/model/repo/Neo4jRepo.kt
+++ b/app/src/main/kotlin/app/model/repo/Neo4jRepo.kt
@@ -51,12 +51,9 @@ class SerializableTreeEntity(
 class Neo4jRepo<E : Comparable<E>,
         Node : BinTreeNode<E, Node>,
         BST : BinarySearchTree<E, Node>>(
-    strategy: SerializationStrategy<E, Node, *>
+    strategy: SerializationStrategy<E, Node, *>,
+    configuration: Configuration
 ) : Repository<E, Node, BST>(strategy) {
-    private val configuration = Configuration.Builder()
-        .uri("bolt://localhost")
-        .credentials("neo4j", "password") //TODO: use settings for this parameters
-        .build()
     private val sessionFactory = SessionFactory(configuration, "app.model.repo")
     private val session = sessionFactory.openSession()
 

--- a/app/src/main/kotlin/app/model/repo/Neo4jRepo.kt
+++ b/app/src/main/kotlin/app/model/repo/Neo4jRepo.kt
@@ -121,7 +121,7 @@ class Neo4jRepo<E : Comparable<E>,
 
     override fun deleteByVerboseName(verboseName: String) {
         session.query(
-            "MATCH toDelete=(t:SerializableTreeEntity {typeOfTree: \$typeOfTree, verboseName : \$verboseName})-[*]->() DETACH DELETE toDelete",
+            "MATCH toDelete=(t:SerializableTreeEntity {typeOfTree: \$typeOfTree, verboseName : \$verboseName})-[*0..]->() DETACH DELETE toDelete",
             mapOf("typeOfTree" to strategy.typeOfTree, "verboseName" to verboseName)
         )
     }

--- a/app/src/main/kotlin/app/model/repo/Neo4jRepo.kt
+++ b/app/src/main/kotlin/app/model/repo/Neo4jRepo.kt
@@ -121,7 +121,7 @@ class Neo4jRepo<E : Comparable<E>,
 
     override fun deleteByVerboseName(verboseName: String) {
         session.query(
-            "MATCH toDelete=(t:SerializableTreeEntity {typeOfTree: '\$typeOfTree', verboseName : '\$verboseName'})-[*]->() DETACH DELETE toDelete",
+            "MATCH toDelete=(t:SerializableTreeEntity {typeOfTree: \$typeOfTree, verboseName : \$verboseName})-[*]->() DETACH DELETE toDelete",
             mapOf("typeOfTree" to strategy.typeOfTree, "verboseName" to verboseName)
         )
     }

--- a/app/src/main/kotlin/app/model/repo/PostgresRepo.kt
+++ b/app/src/main/kotlin/app/model/repo/PostgresRepo.kt
@@ -9,11 +9,15 @@ class PostgresRepo<E : Comparable<E>,
         BST : BinarySearchTree<E, Node>>(
     strategy: SerializationStrategy<E, Node, *>
 ) : Repository<E, Node, BST>(strategy) {
-    override fun save(tree: BST) {
+    override fun save(verboseName: String, tree: BST) {
         TODO("Not yet implemented")
     }
 
-    override fun load(factory: () -> BST): BST {
+    override fun loadByVerboseName(verboseName: String, factory: () -> BST): BST {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteByVerboseName(verboseName: String) {
         TODO("Not yet implemented")
     }
 

--- a/app/src/main/kotlin/app/model/repo/Repository.kt
+++ b/app/src/main/kotlin/app/model/repo/Repository.kt
@@ -3,6 +3,7 @@ package app.model.repo
 import app.model.bst.BinarySearchTree
 import app.model.bst.node.BinTreeNode
 import app.model.repo.serialization.SerializableNode
+import app.model.repo.serialization.SerializableTree
 import app.model.repo.serialization.strategy.SerializationStrategy
 
 abstract class Repository<E : Comparable<E>,
@@ -19,6 +20,16 @@ abstract class Repository<E : Comparable<E>,
         )
     }
 
-    abstract fun save(tree: BST)
-    abstract fun load(factory: () -> BST): BST
+
+    protected fun BST.toSerializableTree(verboseName: String): SerializableTree {
+        return SerializableTree(
+            verboseName = verboseName,
+            typeOfTree = strategy.typeOfTree,
+            root = this.root?.toSerializableNode()
+        )
+    }
+
+    abstract fun save(verboseName: String, tree: BST)
+    abstract fun loadByVerboseName(verboseName: String, factory: () -> BST): BST
+    abstract fun deleteByVerboseName(verboseName: String)
 }

--- a/dev-docker-compose.yml
+++ b/dev-docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.9'
+
+services:
+  neo4j:
+    image: neo4j:latest
+    container_name: neo4j
+    ports:
+      - "7474:7474"
+      - "7687:7687"
+    environment:
+      - NEO4J_AUTH=neo4j/password
+
+  postgres:
+    image: postgres:latest
+    container_name: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=trees


### PR DESCRIPTION
Сохраняет в neo4j дерево, перед этим удалив, предыдущее (Index в OGM не работает)
Удаляет как рут, так и всех потомков.
Поиск возвращает все дерево.
Пока работает только с dev-docker-compose. Settings настраивать еще надо, а времени в обрез.